### PR TITLE
Revert "fix: Remove CI/CD of the python-semantic-release"

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,73 @@
+name: ci-cd
+
+on: [push, pull_request]
+
+jobs:
+  #  ci:
+  #    # Set up operating system
+  #    runs-on: ubuntu-latest
+  #
+  #    # Define job steps
+  #    steps:
+  #      - name: Set up Python
+  #        uses: actions/setup-python@v4
+  #        with:
+  #          python-version: "3.12"
+  #
+  #      - name: Check-out repository
+  #        uses: actions/checkout@v3
+  #
+  #      - name: Install poetry
+  #        uses: snok/install-poetry@v1
+  #
+  #      - name: Install package
+  #        run: poetry install
+  #
+  #      - name: Test with pytest
+  #        run: poetry run pytest tests/ --cov=food_price_tracker --cov-report=xml
+  #
+  #      - name: Use Codecov to track coverage
+  #        uses: codecov/codecov-action@v3
+  #        with:
+  #          files: ./coverage.xml   # coverage report
+  #
+  #      - name: Build documentation
+  #        run: poetry run make html --directory docs/
+
+  cd:
+    permissions:
+      id-token: write
+      contents: write
+    
+        #    # Only run this job if the "ci" job passes
+        #    needs: ci
+
+    # Only run this job if new work is pushed to "main"
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    # Set up operating system
+    runs-on: ubuntu-latest
+
+    # Define job steps
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Check-out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Use Python Semantic Release to prepare release
+        id: release
+        uses: python-semantic-release/python-semantic-release@v8.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish package distributions to GitHub Releases
+        uses: python-semantic-release/upload-to-gh-release@main
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts UBC-MDS/DSCI-532_2024_19_food-price-tracker#19

Attempting to reinstate python semantic release with CI/CD and updated main branch protections