### PR TITLE
fix: Update env .yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,9 +9,9 @@ dependencies:
   - jupyterlab=4.0.9
   - pandas=2.2
   - altair=5.3
-  - vl-convert-python=1.1.0
-  - vegafusion=1.4.5
-  - vegafusion-jupyter=1.4.5
+  - vl-convert-python=1.3.0
+  - vegafusion=1.6.6
+  - vegafusion-jupyter=1.6.6
   - dash=2.16
   - dash-bootstrap-components=1.5
   - dash-daq=0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jupyterlab==4.0.9
 numpy==1.26.4
 pandas==2.2.*
 plotly==5.19.0
-vegafusion==1.4.5
-vegafusion-jupyter==1.4.5
+vegafusion==1.4.5  --> 1.6.6
+vegafusion-jupyter==1.4.5  --> 1.6.6
 vegafusion-python-embed==1.6.6
-vl-convert-python==1.1.0
+vl-convert-python==1.1.0  --> 1.3.0


### PR DESCRIPTION
`vegafusion` 1.4.5 --> 1.6.6
`vegafusion-jupyter` 1.4.5 --> 1.6.6 
This is to fix the error "The versions of the vegafusion and vegafusion-python-embed packages must match and must be version 1.5.0 or greater".

`vl-convert-python` 1.1.0 --> 1.3.0 
This is required by Altair plotting.