### PR TITLE
feat: Combine components

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The project aims to provide an intuitive, interactive data visualization platfor
 4. Start the dashboard.
 
 ```bash
- python src/app.py
+ python -m src.app
 ```
 
 ## Usage

--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,7 @@ import dash_daq as daq
 import pandas as pd
 from io import StringIO
 
-from fetch_data import fetch_country_data, fetch_country_index
+from src.fetch_data import fetch_country_data, fetch_country_index
 
 # Initialize the app (using bootstrap theme)
 app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP]) # need to manually refresh it

--- a/src/app.py
+++ b/src/app.py
@@ -136,7 +136,7 @@ def update_widget_values(country_index_json, country_json, n_clicks):
 
     min_date_allowed = country_data.date.min()
     max_date_allowed = country_data.date.max()
-    start_date = country_data.date.max() + pd.tseries.offsets.DateOffset(months=-6)
+    start_date = country_data.date.max() + pd.tseries.offsets.DateOffset(years=-2)
     end_date = country_data.date.max()
 
     commodities_options = country_data.commodity.unique().tolist()

--- a/src/app.py
+++ b/src/app.py
@@ -48,7 +48,7 @@ sidebar = html.Div(
             id="date-range",
             start_date_placeholder_text = "Start",
             end_date_placeholder_text = "End",
-            updatemode = "bothdates"
+            updatemode = "singledate"
         ),
         html.Br(),
 
@@ -220,7 +220,7 @@ def update_index_area(country_json, start_date, end_date, commodities, markets):
         ["Food Price Index"]
     )[0]
     
-    return dvc.Vega(spec=(figure | line).to_dict(format="vega"))
+    return dvc.Vega(spec=(figure | line).to_dict(format="vega"), style={'width': '60%'})
 
 
 @callback(
@@ -253,7 +253,7 @@ def update_commodities_area(country_json, start_date, end_date, commodities, mar
     )
 
     chart_plots = [
-        dvc.Vega(spec=(figure | line).to_dict(format="vega"))
+        dvc.Vega(spec=(figure | line).to_dict(format="vega"), style={'width': '60%'})
         for line, figure in zip(line_charts, figure_charts)
     ]
     

--- a/src/app.py
+++ b/src/app.py
@@ -82,20 +82,6 @@ content = dbc.Container([
     "margin-right": "2rem",
     "padding": "2rem 1rem",
 })
-#     dbc.Col([
-#         dbc.Row([
-#             dbc.Col(html.Div("index-chart-area", id="index-chart-area", style={'backgroundColor':'lightgrey', "padding":"1.25em"}), md=8),
-#             dbc.Col(html.Div("index-box-area", id="index-box-area", style={'backgroundColor':'lightgrey', "padding":"1.25em"}), md=4)
-#         ], style={'margin-bottom': '1.25em'}),
-
-#         dbc.Row([
-#             dbc.Col(children=None, md=8),
-#             #dbc.Col(html.Div("commodities-chart-area", id="commodities-chart-area", style={'backgroundColor':'lightgrey', "padding":"1.25em"}), md=8),
-            
-#             dbc.Col(html.Div("commodities-box-area", id="commodities-box-area", style={'backgroundColor':'lightgrey', "padding":"1.25em"}), md=4)
-#         ]),
-#     ])
-
 
 app.layout = html.Div([
     sidebar, 
@@ -208,10 +194,13 @@ def update_country_data(country, country_index):
     ]
 )
 def update_index_area(country_json, start_date, end_date, commodities, markets):
+    """
+    FIXME: update docstring
+    """
     country_data = pd.read_json(StringIO(country_json), orient='split')
     country_data = generate_food_price_index_data(country_data, markets, commodities)
     
-    line = generate_line_chart_commodities(
+    line = generate_line_chart(
         country_data, 
         (start_date, end_date), 
         markets,
@@ -245,9 +234,12 @@ def update_index_area(country_json, start_date, end_date, commodities, markets):
     ]
 )
 def update_commodities_area(country_json, start_date, end_date, commodities, markets):
+    """
+    FIXME: update docstring
+    """
     country_data = pd.read_json(StringIO(country_json), orient='split')
     
-    line_charts = generate_line_chart_commodities(
+    line_charts = generate_line_chart(
         country_data, 
         (start_date, end_date), 
         markets,

--- a/src/calc_index.py
+++ b/src/calc_index.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 def generate_food_price_index_data(data, widget_market_values, widget_commodity_values):
     """
-    FIXME
+    FIXME: add docstring
     """
     # Default Info
     columns_to_keep = [

--- a/src/calc_index.py
+++ b/src/calc_index.py
@@ -1,0 +1,127 @@
+import numpy as np
+import pandas as pd
+
+def generate_food_price_index_data(data, widget_market_values, widget_commodity_values):
+    """
+    FIXME
+    """
+    # Default Info
+    columns_to_keep = [
+        "date",
+        "market",
+        "latitude",
+        "longitude",
+        "commodity",
+        "unit",
+        "usdprice",
+    ]
+    
+    # Generate Food Price Index Data
+    price_data = data[columns_to_keep]
+    price_data = price_data[
+        (price_data.commodity.isin(widget_commodity_values))
+        & (price_data.market.isin(widget_market_values))
+    ]
+
+    # Calculate index (formula: arithmetic average of the index by date and market)
+    index = (
+        price_data.groupby(
+            ["date", "market", "latitude", "longitude"]
+        ).agg({
+            "usdprice": "mean"
+        })
+    ).reset_index()
+
+    # Aggregate price index back to the price data
+    index['commodity'] = "Food Price Index"
+    index["unit"] = "PPL"
+    price_data = pd.concat((price_data, index), axis=0)
+
+    return price_data
+
+
+
+# def generate_food_price_index_data(data, widget_date_range, widget_market_values):
+#     """
+#     Generate food price index data based on the input data, date range, and market values.
+
+#     Parameters
+#     ----------
+#     data : pandas.DataFrame
+#         Input food price data.
+#     widget_date_range : tuple
+#         A tuple containing the start and end dates for filtering the data.
+#     widget_market_values : list
+#         A list of market used to filter the data.
+
+#     Returns
+#     -------
+#     pandas.DataFrame
+#         DataFrame containing the food price index data with columns: date, market, latitude, longitude, commodity, unit, usdprice.
+
+#     Examples
+#     --------
+#     >>> import pandas as pd
+#     >>> data = pd.DataFrame({
+#     ...     'date': ['2022-01-01', '2022-01-01', '2022-01-02'],
+#     ...     'market': ['A', 'B', 'A'],
+#     ...     'latitude': [1, 2, 1],
+#     ...     'longitude': [1, 2, 1],
+#     ...     'commodity': ['Rice', 'Radish', 'Sugar'],
+#     ...     'unit': ['kg', 'kg', 'kg'],
+#     ...     'usdprice': [1.0, 2.0, 3.0]
+#     ... })
+#     >>> widget_date_range = ('2022-01-01', '2022-01-02')
+#     >>> widget_market_values = ['A', 'B']
+#     >>> generate_food_price_index_data(data, widget_date_range, widget_market_values)
+#     """
+
+#     # Default Info
+#     columns_to_keep = [
+#         "date",
+#         "market",
+#         "latitude",
+#         "longitude",
+#         "commodity",
+#         "unit",
+#         "usdprice",
+#     ]
+#     food_price_index_dict = {
+#         "Rice": 0.156,
+#         "Radish": 0.23,
+#         "Sugar": 0.036,
+#     }
+
+#     # Generate Food Price Index Data
+#     price_index_data = data[columns_to_keep]
+#     price_index_data = price_index_data[
+#         price_index_data.date.between(
+#             widget_date_range[0], widget_date_range[1]
+#         )
+#         & (price_index_data.market.isin(widget_market_values))
+#     ]
+#     price_index_data["index_weight"] = price_index_data[
+#         "commodity"
+#     ].apply(
+#         lambda x: food_price_index_dict[x]
+#         if x in food_price_index_dict
+#         else np.nan
+#     )
+#     price_index_data["usdprice"] = (
+#         price_index_data["usdprice"]
+#         * price_index_data["index_weight"]
+#     )
+#     price_index_data["commodity"] = "Food Price Index"
+#     price_index_data["unit"] = "PPL"
+#     price_index_data = price_index_data.dropna()
+#     price_index_data = (
+#         price_index_data.groupby(columns_to_keep[:-1])
+#         .agg({"usdprice": "sum", "index_weight": "count"})
+#         .reset_index()
+#     )
+#     price_index_data = price_index_data[
+#         price_index_data.index_weight
+#         == len(food_price_index_dict)
+#     ].drop(columns=["index_weight"])
+
+#     return price_index_data

--- a/src/fetch_data.py
+++ b/src/fetch_data.py
@@ -14,7 +14,8 @@ Configuration.create(
 
 
 def fetch_country_index():
-    """Fetch country index and preprocess into dataframe.
+    """
+    Fetch country index and preprocess into dataframe.
 
     Returns
     -------
@@ -45,7 +46,8 @@ def fetch_country_index():
 
 
 def fetch_country_data(country, country_index_json=fetch_country_index()):
-    """Fetch and preprocess data from HDX (https://data.humdata.org/)
+    """
+    Fetch and preprocess data from HDX (https://data.humdata.org/)
     Dynamically load the corresponding country dataset and preprocess.
 
     Parameters

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -3,91 +3,6 @@ import pandas as pd
 import altair as alt
 alt.data_transformers.enable('vegafusion')
 
-def generate_food_price_index_data(data, widget_date_range, widget_market_values):
-    """
-    Generate food price index data based on the input data, date range, and market values.
-
-    Parameters
-    ----------
-    data : pandas.DataFrame
-        Input food price data.
-    widget_date_range : tuple
-        A tuple containing the start and end dates for filtering the data.
-    widget_market_values : list
-        A list of market used to filter the data.
-
-    Returns
-    -------
-    pandas.DataFrame
-        DataFrame containing the food price index data with columns: date, market, latitude, longitude, commodity, unit, usdprice.
-
-    Examples
-    --------
-    >>> import pandas as pd
-    >>> data = pd.DataFrame({
-    ...     'date': ['2022-01-01', '2022-01-01', '2022-01-02'],
-    ...     'market': ['A', 'B', 'A'],
-    ...     'latitude': [1, 2, 1],
-    ...     'longitude': [1, 2, 1],
-    ...     'commodity': ['Rice', 'Radish', 'Sugar'],
-    ...     'unit': ['kg', 'kg', 'kg'],
-    ...     'usdprice': [1.0, 2.0, 3.0]
-    ... })
-    >>> widget_date_range = ('2022-01-01', '2022-01-02')
-    >>> widget_market_values = ['A', 'B']
-    >>> generate_food_price_index_data(data, widget_date_range, widget_market_values)
-    """
-
-    # Default Info
-    columns_to_keep = [
-        "date",
-        "market",
-        "latitude",
-        "longitude",
-        "commodity",
-        "unit",
-        "usdprice",
-    ]
-    food_price_index_dict = {
-        "Rice": 0.156,
-        "Radish": 0.23,
-        "Sugar": 0.036,
-    }
-
-    # Generate Food Price Index Data
-    price_index_data = data[columns_to_keep]
-    price_index_data = price_index_data[
-        price_index_data.date.between(
-            widget_date_range[0], widget_date_range[1]
-        )
-        & (price_index_data.market.isin(widget_market_values))
-    ]
-    price_index_data["index_weight"] = price_index_data[
-        "commodity"
-    ].apply(
-        lambda x: food_price_index_dict[x]
-        if x in food_price_index_dict
-        else np.nan
-    )
-    price_index_data["usdprice"] = (
-        price_index_data["usdprice"]
-        * price_index_data["index_weight"]
-    )
-    price_index_data["commodity"] = "Food Price Index"
-    price_index_data["unit"] = "PPL"
-    price_index_data = price_index_data.dropna()
-    price_index_data = (
-        price_index_data.groupby(columns_to_keep[:-1])
-        .agg({"usdprice": "sum", "index_weight": "count"})
-        .reset_index()
-    )
-    price_index_data = price_index_data[
-        price_index_data.index_weight
-        == len(food_price_index_dict)
-    ].drop(columns=["index_weight"])
-
-    return price_index_data
-
 def generate_figure_chart(data, widget_date_range, widget_market_values, widget_commodity_values):
     """
     Generate figure charts displaying the latest average price and period-over-period change for specified commodities.
@@ -308,7 +223,7 @@ def generate_line_chart_fpi(data, widget_date_range, widget_market_values):
             alt.Tooltip('usdprice:Q', title='Value', format='.2f')
         ]
     ).properties(
-        title=alt.TitleParams('Food Price Index Over Time')
+        title=alt.TitleParams('Food Price Index')
     ).configure_axis(
             grid=False
     ).interactive()

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -137,19 +137,19 @@ def generate_figure_chart(data, widget_date_range, widget_market_values, widget_
         "usdprice",
     ]
 
-    # Obtain Food Price Index data
-    price_index_data = generate_food_price_index_data(data, widget_date_range, widget_market_values)
-    widget_commodity_values = [
-        "Food Price Index"
-    ] + widget_commodity_values
+    # # Obtain Food Price Index data
+    # price_index_data = generate_food_price_index_data(data, widget_date_range, widget_market_values)
+    # widget_commodity_values = []
+    #     "Food Price Index"
+    # ] + widget_commodity_values
 
     # Generate latest average price and period-over-period change
     price_data = data[columns_to_keep]
-    price_data = pd.concat(
-        [price_data, price_index_data],
-        axis=0,
-        ignore_index=True,
-    )
+    # price_data = pd.concat(
+    #     [price_data, price_index_data],
+    #     axis=0,
+    #     ignore_index=True,
+    # )
     price_data = price_data[
         price_data.date.between(
             widget_date_range[0], widget_date_range[1]
@@ -267,7 +267,8 @@ def generate_figure_chart(data, widget_date_range, widget_market_values, widget_
             + yoy_value
             + yoy_title
         )
-        charts.append(chart.interactive())
+        #charts.append(chart.interactive())
+        charts.append(chart)
 
     return charts
 
@@ -321,17 +322,25 @@ def generate_line_chart_commodities(data, widget_date_range, widget_market_value
     The function filters the input data based on a given date range and a list of market values. 
     It then iterates through a list of commodities, creating an individual line chart for each one that visualizes its price trend in USD.
 
-    Parameters:
-    - data (DataFrame): A Pandas DataFrame containing the commodities data including dates, markets, and prices.
-    - widget_date_range (tuple): A tuple of two strings ('YYYY-MM-DD', 'YYYY-MM-DD') representing the start and end dates for filtering the data.
-    - widget_market_values (list of str): A list of string values representing the markets to include in the chart.
-    - widget_commodity_values (list of str): A list of string values representing the commodities for which the line charts will be generated.
+    Parameters
+    ----------
+    data : pd.DataFrame
+        A Pandas DataFrame containing the commodities data including dates, markets, and prices.
+        
+    widget_date_range : tuple
+        A tuple of two strings ('YYYY-MM-DD', 'YYYY-MM-DD') representing the start and end dates for filtering the data.
+        
+    widget_market_values : list of str)
+        A list of string values representing the markets to include in the chart.
+    
+    widget_commodity_values : list of str)
+        A list of string values representing the commodities for which the line charts will be generated.
 
     Returns:
-    - charts (list of alt.Chart): A list containing Altair Chart objects, each representing a line chart for a specific commodity.
-
-    Each chart visualizes the price trend for a specific commodity across all specified markets over the given time period. 
-    The y-axis shows the price in USD, and the x-axis shows time by year. 
+    list of alt.Chart
+        A list containing Altair Chart objects, each representing a line chart for a specific commodity.
+        Each chart visualizes the price trend for a specific commodity across all specified markets over the given time period. 
+        The y-axis shows the price in USD, and the x-axis shows time by year. 
 
     Example:
     >>> generate_line_chart_commodities(df, ('2011-01-01', '2022-01-01'), ['Osaka', 'Tokyo'], ['Rice', 'Milk'])
@@ -361,10 +370,10 @@ def generate_line_chart_commodities(data, widget_date_range, widget_market_value
                 alt.Tooltip('usdprice:Q', title='Price in USD', format='.2f')
             ]
         ).properties(
-            title=alt.TitleParams(f'Price of {commodity} Over Time')
-        ).configure_axis(
-            grid=False
-        ).interactive()
+            title=alt.TitleParams(f'{commodity} Price')
+        ) #.configure_axis(
+        #    grid=False
+        #) #.interactive()
 
         # Add the chart to the list of charts
         charts.append(chart)

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -221,12 +221,12 @@ def generate_line_chart(data, widget_date_range, widget_market_values, widget_co
         commodity_data = commodities_data[commodities_data.commodity.isin([commodity])]
      
         # Create the chart
-        chart = alt.Chart(commodity_data).mark_line().encode(
-            x=alt.X('date:T', axis=alt.Axis(format='%Y', title='Year')),
+        chart = alt.Chart(commodity_data, width='container').mark_line().encode(
+            x=alt.X('date:T', axis=alt.Axis(format='%Y-%m', title='Time')),
             y=alt.Y('usdprice:Q', title='Price in USD', scale=alt.Scale(zero=False)),
             color=alt.Color('market:N', legend=alt.Legend(title='Market')),
             tooltip=[
-                alt.Tooltip('date:T', title='Time', format='%b, %Y'),
+                alt.Tooltip('date:T', title='Time', format='%Y-%m'),
                 alt.Tooltip('usdprice:Q', title='Price in USD', format='.2f')
             ]
         ).properties(

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -52,19 +52,8 @@ def generate_figure_chart(data, widget_date_range, widget_market_values, widget_
         "usdprice",
     ]
 
-    # # Obtain Food Price Index data
-    # price_index_data = generate_food_price_index_data(data, widget_date_range, widget_market_values)
-    # widget_commodity_values = []
-    #     "Food Price Index"
-    # ] + widget_commodity_values
-
     # Generate latest average price and period-over-period change
     price_data = data[columns_to_keep]
-    # price_data = pd.concat(
-    #     [price_data, price_index_data],
-    #     axis=0,
-    #     ignore_index=True,
-    # )
     price_data = price_data[
         price_data.date.between(
             widget_date_range[0], widget_date_range[1]
@@ -182,57 +171,13 @@ def generate_figure_chart(data, widget_date_range, widget_market_values, widget_
             + yoy_value
             + yoy_title
         )
-        #charts.append(chart.interactive())
         charts.append(chart)
 
     return charts
 
-def generate_line_chart_fpi(data, widget_date_range, widget_market_values):
+def generate_line_chart(data, widget_date_range, widget_market_values, widget_commodity_values):
     """
-    Generates an interactive line chart visualizing the Food Price Index over time.
-
-    This function filters the Food Price Index data based on the specified date range and market values. 
-    It then creates an interactive Altair line chart with custom tooltip formatting, axis titles, and legend configuration. 
-    The chart displays the Food Price Index on the y-axis and time on the x-axis, represented by years. 
-
-    Parameters:
-    - data (DataFrame): The source Pandas DataFrame containing the Food Price Index data.
-    - widget_date_range (tuple): A tuple containing the start and end dates (inclusive) as strings in 'YYYY-MM-DD' format to filter the data by.
-    - widget_market_values (list): A list of markets to include in the chart.
-
-    Returns:
-    - price_index_line_chart (alt.Chart): An Altair Chart object representing the line chart of the Food Price Index data.
-
-    The `generate_food_price_index_data` function is called within to process the raw data, which is expected to be defined externally to this function.
-
-    Example:
-    >>> generate_line_chart_fpi(df, ('2011-01-01', '2022-01-01'), ['Osaka', 'Tokyo'])
-    # Returns an Altair Chart object with the Food Price Index line chart.
-    """
-
-    # Obtain Food Price Index data
-    price_index_data = generate_food_price_index_data(data, widget_date_range, widget_market_values)
-
-    # Create a line chart for Food Price Index
-    price_index_line_chart = alt.Chart(price_index_data).mark_line().encode(
-        x=alt.X('date:T', axis=alt.Axis(format='%Y', title='Year')),
-        y=alt.Y('usdprice:Q', title='Food Price Index', scale=alt.Scale(zero=False)),
-        color=alt.Color('market:N', legend=alt.Legend(title='Market')),
-        tooltip=[
-            alt.Tooltip('date:T', title='Time', format='%b, %Y'),
-            alt.Tooltip('usdprice:Q', title='Value', format='.2f')
-        ]
-    ).properties(
-        title=alt.TitleParams('Food Price Index')
-    ).configure_axis(
-            grid=False
-    ).interactive()
-
-    return price_index_line_chart
-
-def generate_line_chart_commodities(data, widget_date_range, widget_market_values, widget_commodity_values):
-    """
-    Generates a list of interactive line charts, each representing the price trends of different commodities over time within specified marketplaces.
+    Generates a list of line charts, each representing the price trends of different commodities over time within specified marketplaces.
 
     The function filters the input data based on a given date range and a list of market values. 
     It then iterates through a list of commodities, creating an individual line chart for each one that visualizes its price trend in USD.
@@ -258,7 +203,7 @@ def generate_line_chart_commodities(data, widget_date_range, widget_market_value
         The y-axis shows the price in USD, and the x-axis shows time by year. 
 
     Example:
-    >>> generate_line_chart_commodities(df, ('2011-01-01', '2022-01-01'), ['Osaka', 'Tokyo'], ['Rice', 'Milk'])
+    >>> generate_line_chart(df, ('2011-01-01', '2022-01-01'), ['Osaka', 'Tokyo'], ['Rice', 'Milk'])
     # Returns a list of Altair Chart objects for 'Rice' and 'Milk' with specified configurations.
     """
 
@@ -286,9 +231,7 @@ def generate_line_chart_commodities(data, widget_date_range, widget_market_value
             ]
         ).properties(
             title=alt.TitleParams(f'{commodity} Price')
-        ) #.configure_axis(
-        #    grid=False
-        #) #.interactive()
+        )
 
         # Add the chart to the list of charts
         charts.append(chart)


### PR DESCRIPTION
 - moved the `generate_food_price_index_data` to a separated file
   - simplified the index calculation for the moment (we can revise the formula at the later time)
 - disabled interactivity and grid=False configuration for the moment (to make the altair horizontal concat working) 
 - combined two line chart plotting functions into a single `generate_line_chart`, the same function can be for both commodities and index 
 - removed the index calculation in `generate_figure_chart`, this function is re-used for index plotting separately
 - added subtitle in the index plot to explain how the index is being calculated
 - swapped the position of line chart and figure chart, because, otherwise, the separation between them is either too wide (if using dvc.Col to combine the two chart horizontally) or too narrow (if using altair `|` to combine) for unknown reason.
 - updated README: we should use `python -m src.app` to start the app from now on